### PR TITLE
Fix bulk string read

### DIFF
--- a/lib/Redisent/Redisent.php
+++ b/lib/Redisent/Redisent.php
@@ -101,8 +101,13 @@ class Redisent {
                 $size = substr($reply, 1);
                 do {
                     $block_size = ($size - $read) > 1024 ? 1024 : ($size - $read);
-                    $response .= fread($this->__sock, $block_size);
-                    $read += $block_size;
+                    $r = fread($this->__sock, $block_size);
+                    if ($r === false) {
+                        throw new \Exception('Failed to read response from stream');
+                    } else {
+                        $response .= $r;
+                        $read += strlen($r);
+                    }
                 } while ($read < $size);
                 fread($this->__sock, 2); /* discard crlf */
                 break;
@@ -124,8 +129,13 @@ class Redisent {
                         $block = "";
                         do {
                             $block_size = ($size - $read) > 1024 ? 1024 : ($size - $read);
-                            $block .= fread($this->__sock, $block_size);
-                            $read += $block_size;
+                            $r = fread($this->__sock, $block_size);
+                            if ($r === false) {
+                                throw new \Exception('Failed to read response from stream');
+                            } else {
+                                $block .= $r;
+                                $read += strlen($r);
+                            }
                         } while ($read < $size);
                         fread($this->__sock, 2); /* discard crlf */
                         $response[] = $block;


### PR DESCRIPTION
When Redis returns a bulk string, Redisent reads from the socket in chunks of
up to 1024 characters. Unfortunately, instead of keeping track of how many
characters were actually read in each chunk, the read position is just
incremented by 1024. This fix addresses this issue by only adding the number of
characters actually read in each block, rather than what we expected to read.

In especially large responses, this was causing issues where Redisent was
overcounting how many characters it had read, and was therefore returning
incomplete responses and leaving stray characters in the socket buffer, which
would break the next command.
