### PR TITLE
Add queue_time to Resque jobs

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -63,9 +63,10 @@ class Resque_Job
 		}
 		$id = md5(uniqid('', true));
 		Resque::push($queue, array(
-			'class'	=> $class,
-			'args'	=> array($args),
-			'id'	=> $id,
+			'class' => $class,
+			'args' => array($args),
+			'id' => $id,
+			'queue_time' => microtime(true),
 		));
 
 		if($monitor) {


### PR DESCRIPTION
This will allow us to track the total time each job spent in the queue.
Re: https://github.com/chrisboulton/php-resque/pull/206
